### PR TITLE
Clean up shell config transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 .DS_Store
 home/.emacs.d/savehist
+# Sensitive/private configs
+**/.aws-*
+**/.dont-track.*
+**/auth
+**/credentials
+**/*-auth
+**/*-token
+**/*-secret
+**/*-key

--- a/home/.zshrc.d/.fzf
+++ b/home/.zshrc.d/.fzf
@@ -1,1 +1,0 @@
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh

--- a/home/.zshrc.d/.ohmyzsh_plugins
+++ b/home/.zshrc.d/.ohmyzsh_plugins
@@ -1,3 +1,0 @@
-zgenom oh-my-zsh plugins/tmux
-zgenom oh-my-zsh plugins/z
-zgenom oh-my-zsh plugins/git


### PR DESCRIPTION
- Remove redundant .fzf config (fish gets fzf via homebrew)
- Delete unused .ohmyzsh_plugins (migrated to fish + starship)
- Add gitignore patterns for sensitive files (.aws-*, auth, credentials, etc.)
- Protect local AWS helpers and auth tokens from being committed